### PR TITLE
Added ability in Maven plugin to specify an internal repo URL

### DIFF
--- a/burp-api/pom.xml
+++ b/burp-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.h3xstream.retirejs</groupId>
         <artifactId>retirejs-root-pom</artifactId>
-        <version>2.1.0</version>
+        <version>2.1.1-SNAPSHOT</version>
     </parent>
     
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.h3xstream.retirejs</groupId>
     <artifactId>retirejs-root-pom</artifactId>
-    <version>2.1.0</version>
+    <version>2.1.1-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 

--- a/retirejs-burp-plugin/pom.xml
+++ b/retirejs-burp-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.h3xstream.retirejs</groupId>
         <artifactId>retirejs-root-pom</artifactId>
-        <version>2.1.0</version>
+        <version>2.1.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/retirejs-core/pom.xml
+++ b/retirejs-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.h3xstream.retirejs</groupId>
         <artifactId>retirejs-root-pom</artifactId>
-        <version>2.1.0</version>
+        <version>2.1.1-SNAPSHOT</version>
     </parent>
     
     <modelVersion>4.0.0</modelVersion>

--- a/retirejs-core/src/main/java/com/h3xstream/retirejs/repo/ScannerFacade.java
+++ b/retirejs-core/src/main/java/com/h3xstream/retirejs/repo/ScannerFacade.java
@@ -19,7 +19,7 @@ public class ScannerFacade {
      * @param repo Mock repository (For testing purpose)
      * @throws IOException Unable to load the repository
      */
-    protected ScannerFacade(VulnerabilitiesRepository repo) throws IOException {
+    public ScannerFacade(VulnerabilitiesRepository repo) throws IOException {
         this.repo = repo;
     }
 

--- a/retirejs-core/src/main/java/com/h3xstream/retirejs/repo/VulnerabilitiesRepositoryLoader.java
+++ b/retirejs-core/src/main/java/com/h3xstream/retirejs/repo/VulnerabilitiesRepositoryLoader.java
@@ -19,13 +19,17 @@ public class VulnerabilitiesRepositoryLoader {
      */
     public static boolean syncWithOnlineRepository = true;
 
+    /**
+     * The default repository URL
+     */
+    public static final String REPO_URL = "https://raw.githubusercontent.com/Retirejs/retire.js/master/repository/jsrepository.json";
 
-    public VulnerabilitiesRepository load() throws IOException {
+    public VulnerabilitiesRepository load(String url) throws IOException {
         InputStream inputStream = null;
 
         if (syncWithOnlineRepository) { //Remote repository
             try {
-                URL remoteRepo = new URL("https://raw.githubusercontent.com/Retirejs/retire.js/master/repository/jsrepository.json");
+                URL remoteRepo = new URL(url);
                 //URL remoteRepo = new URL("https://raw.githubusercontent.com/RetireJS/retire.js/secdec-feature/identifiers/repository/jsrepository.json");
                 URLConnection conn = remoteRepo.openConnection();
                 conn.connect();
@@ -37,7 +41,8 @@ public class VulnerabilitiesRepositoryLoader {
                 Log.error("Exception while loading the repository (Most likely unable to access the internet) " +
                         exception.getClass().getName() + ": " + exception.getMessage());
             } catch (IOException exception) { //If an problem occurs with the online file, the local repository is used.
-                Log.error("Exception while loading the repository (Connection problem while loading latest repository from GitHub) " +
+                Log.error("Exception while loading the repository (Connection problem while loading latest repository from "
+                        + repoUrl + ") " +
                         exception.getClass().getName() + ": " + exception.getMessage());
             } catch (RuntimeException exception) {
                 Log.error("Exception while loading the repository (Unable to access GitHub ?) " +
@@ -50,6 +55,10 @@ public class VulnerabilitiesRepositoryLoader {
         Log.info("Loading the local Retire.js repository (old cache version)");
         inputStream = getClass().getResourceAsStream("/retirejs_repository.json");
         return loadFromInputStream(inputStream);
+    }
+
+    public VulnerabilitiesRepository load() throws IOException {
+        return load(REPO_URL);
     }
 
     public VulnerabilitiesRepository loadFromInputStream(InputStream in) throws IOException {

--- a/retirejs-core/src/main/java/com/h3xstream/retirejs/repo/VulnerabilitiesRepositoryLoader.java
+++ b/retirejs-core/src/main/java/com/h3xstream/retirejs/repo/VulnerabilitiesRepositoryLoader.java
@@ -42,7 +42,7 @@ public class VulnerabilitiesRepositoryLoader {
                         exception.getClass().getName() + ": " + exception.getMessage());
             } catch (IOException exception) { //If an problem occurs with the online file, the local repository is used.
                 Log.error("Exception while loading the repository (Connection problem while loading latest repository from "
-                        + repoUrl + ") " +
+                        + url + ") " +
                         exception.getClass().getName() + ": " + exception.getMessage());
             } catch (RuntimeException exception) {
                 Log.error("Exception while loading the repository (Unable to access GitHub ?) " +

--- a/retirejs-maven-plugin/pom.xml
+++ b/retirejs-maven-plugin/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.h3xstream.retirejs</groupId>
         <artifactId>retirejs-root-pom</artifactId>
-        <version>2.1.0</version>
+        <version>2.1.1-SNAPSHOT</version>
     </parent>
     
     <modelVersion>4.0.0</modelVersion>

--- a/retirejs-maven-plugin/src/main/java/com/h3xstream/retirejs/RetireJsScan.java
+++ b/retirejs-maven-plugin/src/main/java/com/h3xstream/retirejs/RetireJsScan.java
@@ -4,6 +4,8 @@ import com.esotericsoftware.minlog.Log;
 import com.h3xstream.retirejs.repo.JsLibrary;
 import com.h3xstream.retirejs.repo.JsLibraryResult;
 import com.h3xstream.retirejs.repo.ScannerFacade;
+import com.h3xstream.retirejs.repo.VulnerabilitiesRepository;
+import com.h3xstream.retirejs.repo.VulnerabilitiesRepositoryLoader;
 import org.apache.commons.io.IOUtils;
 import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.AbstractMojo;
@@ -38,6 +40,12 @@ public class RetireJsScan extends AbstractMojo {
      * @parameter property = "retireJsBreakOnFailure" defaultValue = false
      */
     protected boolean breakOnFailure;
+
+    /**
+     * This parameter will override the default public repo URL with the one specified.
+     * @parameter property = "retireJsRepoUrl" defaultValue = "https://raw.githubusercontent.com/Retirejs/retire.js/master/repository/jsrepository.json"
+     */
+    protected String repoUrl;
 
 
     /**
@@ -171,7 +179,9 @@ public class RetireJsScan extends AbstractMojo {
 
         //Scan
         byte[] fileContent = IOUtils.toByteArray(new FileInputStream(javascriptFile));
-        List<JsLibraryResult> results = ScannerFacade.getInstance().scanScript(javascriptFile.getAbsolutePath(),fileContent,0);
+        VulnerabilitiesRepository repo = new VulnerabilitiesRepositoryLoader().load(repoUrl);
+        ScannerFacade scanner = new ScannerFacade(repo);
+        List<JsLibraryResult> results = scanner.scanScript(javascriptFile.getAbsolutePath(),fileContent,0);
         completeResults.addAll(results);
 
         //Display the results

--- a/retirejs-zap-plugin/pom.xml
+++ b/retirejs-zap-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.h3xstream.retirejs</groupId>
         <artifactId>retirejs-root-pom</artifactId>
-        <version>2.1.0</version>
+        <version>2.1.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
For folks behind a proxy, and they don't want to specify proxy information for the remainder of the Maven build, this allows you to specify a URL to load the jsrepository.json from. Unfortunately, this required making the constructor for ScannerFacade public, in which case, the whole notion of it being a singleton no longer works. One way to deal with this is to ditch the singleton notion, but this would require changes in everything that uses core. Another would be to use a system property for the URL rather than injection as is done here. If you're more comfortable with one of those approaches, I'll be happy to make the appropriate changes.