### PR TITLE
Allow forcing scan even when packaging=pom

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,17 @@ The additional parameter `-DretireJsBreakOnFailure` can be use to break the buil
     [ERROR] Failed to execute goal com.h3xstream.retirejs:retirejs-maven-plugin:1.0.0:scan (default-cli) on project
     my-web-app: 6 known vulnerabilities were identified in the JavaScript librairies. -> [Help 1]
     [ERROR]
+
+The additional parameter `-DretireForceScan` can be used to force scanning of projects
+with packaging pom:
+
+    $ mvn com.h3xstream.retirejs:retirejs-maven-plugin:scan -DretireForceScan 
+    [INFO] Scanning for projects...
+    [INFO] 
+    [INFO] ------------------------------------------------------------------------
+    [INFO] Building Reggie Client Project 1.1.0-SNAPSHOT
+    [INFO] ------------------------------------------------------------------------
+    [INFO] 
+    [INFO] --- retirejs-maven-plugin:2.1.1-SNAPSHOT:scan (default-cli) @ client ---
+    [INFO] Scanning directory: client
+    [WARNING] jquery.min.js contains a vulnerable JavaScript library.

--- a/retirejs-core/src/main/java/com/h3xstream/retirejs/repo/VulnerabilitiesRepositoryLoader.java
+++ b/retirejs-core/src/main/java/com/h3xstream/retirejs/repo/VulnerabilitiesRepositoryLoader.java
@@ -37,6 +37,9 @@ public class VulnerabilitiesRepositoryLoader {
     }
 
     public VulnerabilitiesRepository load(String url, Downloader dl) throws IOException {
+        if (url == null || url.length() == 0) {
+            throw new IllegalArgumentException("url is null or empty");
+        }
 
         String homeDir = System.getProperty("user.home");
         File cacheDir = new File(homeDir, ".retirejs");

--- a/retirejs-maven-plugin/src/main/java/com/h3xstream/retirejs/MavenDownloader.java
+++ b/retirejs-maven-plugin/src/main/java/com/h3xstream/retirejs/MavenDownloader.java
@@ -35,6 +35,10 @@ public class MavenDownloader implements Downloader {
 
     @Override
     public void downloadUrlToFile(String url, File file) throws Exception {
+        if (url == null || url.length() == 0) {
+            throw new IllegalArgumentException("url is null or empty");
+        }
+
         Wagon w = wagonManager.getWagon(repo);
 
         w.connect(repo, wagonManager.getProxy(repo.getProtocol()));

--- a/retirejs-maven-plugin/src/main/java/com/h3xstream/retirejs/RetireJsScan.java
+++ b/retirejs-maven-plugin/src/main/java/com/h3xstream/retirejs/RetireJsScan.java
@@ -77,7 +77,7 @@ public class RetireJsScan extends AbstractMojo {
     /**
      * Directory containing web resources files (by default src/main/webapp)
      *
-     * @parameter default-value="${basedir}/src/main/webapp"
+     * @parameter property = "retireWebAppDir" default-value="${basedir}/src/main/webapp"
      * @required
      */
     protected File webAppDirectory;

--- a/retirejs-maven-plugin/src/main/java/com/h3xstream/retirejs/RetireJsScan.java
+++ b/retirejs-maven-plugin/src/main/java/com/h3xstream/retirejs/RetireJsScan.java
@@ -116,6 +116,9 @@ public class RetireJsScan extends AbstractMojo {
             return;
         }
 
+        if (repoUrl == null || repoUrl.length() == 0) {
+            throw new RuntimeException("retireJsRepoUrl is null or empty");
+        }
 
         try {
             repo = new VulnerabilitiesRepositoryLoader().load(repoUrl,new MavenDownloader(getLog(),wagonManager));

--- a/retirejs-maven-plugin/src/main/java/com/h3xstream/retirejs/RetireJsScan.java
+++ b/retirejs-maven-plugin/src/main/java/com/h3xstream/retirejs/RetireJsScan.java
@@ -52,6 +52,11 @@ public class RetireJsScan extends AbstractMojo {
      */
     protected String repoUrl;
 
+    /**
+     * This parameter will override behavior to abort scan if project packaging is pom.
+     * @parameter property = "retireForceScan" defaultValue = false
+     */
+    protected boolean forceScan;
 
     /**
      * The Maven Project. (Inject component)
@@ -111,8 +116,12 @@ public class RetireJsScan extends AbstractMojo {
         File baseDir = project.getBasedir();
         String packaging = project.getPackaging();
 
-        if("pom".equals(packaging)) {
-            getLog().debug("Skipping " + project.getGroupId() + ":" + project.getArtifactId()+" for not being a code project.");
+        if(!forceScan && "pom".equals(packaging)) {
+            getLog().info("Skipping "
+                    + project.getGroupId()
+                    + ":"
+                    + project.getArtifactId()
+                    + " for not being a code project. Hint: You can force scanning with parameter retireForceScan.");
             return;
         }
 
@@ -139,7 +148,7 @@ public class RetireJsScan extends AbstractMojo {
                 if(res.getDirectory() == null) continue;
                 File sourceDir = new File(res.getDirectory());
                 if(sourceDir.exists()) {
-                    getLog().debug("Scanning directory: "+sourceDir.toString());
+                    getLog().info("Scanning directory: "+sourceDir.toString());
                     scanDirectory(sourceDir, completeResults);
                 }
             }
@@ -147,7 +156,7 @@ public class RetireJsScan extends AbstractMojo {
             //WebApp directory
 
             if(webAppDirectory != null && webAppDirectory.exists()) {
-                getLog().debug("Scanning directory: "+webAppDirectory.toString());
+                getLog().info("Scanning directory: "+webAppDirectory.toString());
                 scanDirectory(webAppDirectory, completeResults);
             }
 

--- a/retirejs-maven-plugin/src/main/java/com/h3xstream/retirejs/RetireJsScan.java
+++ b/retirejs-maven-plugin/src/main/java/com/h3xstream/retirejs/RetireJsScan.java
@@ -154,9 +154,14 @@ public class RetireJsScan extends AbstractMojo {
             }
 
             //WebApp directory
-
-            if(webAppDirectory != null && webAppDirectory.exists()) {
-                getLog().info("Scanning directory: "+webAppDirectory.toString());
+            if (webAppDirectory == null) {
+                getLog().info("Not scanning webAppDirectory since it's null.");
+            } else if (!webAppDirectory.exists()) {
+                getLog().info("Not scanning webAppDirectory ("
+                        + webAppDirectory.getAbsolutePath()
+                        + ") since it doesn't exist.");
+            } else {
+                getLog().info("Scanning directory: " + webAppDirectory.toString());
                 scanDirectory(webAppDirectory, completeResults);
             }
 


### PR DESCRIPTION
With reference to issue #16 I've created a pull request with some changes:
- Added parameter retireForceScan which forces scanning even when packaging is set to pom
- Logging level when scanning directories is set to INFO instead of DEBUG for the user to be able to know whats happening.
- Added parameter retireWebAppDir to be able to set the webAppDirectory from command line.
- Some input validation (checking for null) of the url.