### PR TITLE
Return correct ID in ZAP passive scanner

### DIFF
--- a/retirejs-zap-plugin/src/main/java/org/zaproxy/zap/extension/retirejs/RetireJsScannerPlugin.java
+++ b/retirejs-zap-plugin/src/main/java/org/zaproxy/zap/extension/retirejs/RetireJsScannerPlugin.java
@@ -20,7 +20,7 @@ public class RetireJsScannerPlugin extends PluginPassiveScanner {
 
     private PassiveScanThread parent = null;
 
-    private static int PLUGIN_ID = 0x1337BEEF;
+    private static final int PLUGIN_ID = 0x1337BEEF;
 
     private Logger logger = Logger.getLogger(RetireJsScannerPlugin.class);
 
@@ -79,5 +79,10 @@ public class RetireJsScannerPlugin extends PluginPassiveScanner {
     @Override
     public String getName() {
         return "Retire.js";
+    }
+
+    @Override
+    public int getPluginId() {
+        return PLUGIN_ID;
     }
 }


### PR DESCRIPTION
Change RetireJsScannerPlugin to return the correct ID (0x1337BEEF
instead of default -1), also, set the ID as constant.