### PR TITLE
Use correct version in ZAP add-on manifest

### DIFF
--- a/retirejs-zap-plugin/pom.xml
+++ b/retirejs-zap-plugin/pom.xml
@@ -18,6 +18,23 @@
 
     <packaging>jar</packaging>
 
+    <properties>
+        <zap.addon.version>4</zap.addon.version>
+        <zap.addon.status>alpha</zap.addon.status>
+    </properties>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+            <resource>
+                <directory>src/main/resources-filtered</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
+
     <profiles>
         <profile>
             <id>bigjar</id> <!-- Need to be deactivate during Maven release -->
@@ -43,7 +60,7 @@
                                     <descriptorRefs>
                                         <descriptorRef>jar-with-dependencies</descriptorRef>
                                     </descriptorRefs>
-                                    <finalName>retirejs-alpha-3</finalName>
+                                    <finalName>retirejs-${zap.addon.status}-${zap.addon.version}</finalName>
                                     <appendAssemblyId>false</appendAssemblyId>
                                     <archive>
                                         <addMavenDescriptor>false</addMavenDescriptor>

--- a/retirejs-zap-plugin/src/main/resources-filtered/ZapAddOn.xml
+++ b/retirejs-zap-plugin/src/main/resources-filtered/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
     <name>Retire.js</name>
-    <version>1</version>
+    <version>${zap.addon.version}</version>
+    <status>${zap.addon.status}</status>
     <description>Identify vulnerable JavaScript libraries</description>
     <author>Philippe Arteau (h3xStream)</author>
     <url>https://github.com/h3xstream/burp-retire-js</url>


### PR DESCRIPTION
Change the build to include the correct version (and status, same as the
ones used in the file name) in the manifest of the add-on.
Bump add-on version to 4.