### PR TITLE
Upgrade to Java 8 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: java
 #install: mvn install:install-file -Dfile=libs/zap-2.4.3.jar -DgroupId=org.zaproxy -DartifactId=zaproxy -Dversion=2.4.3 -Dpackaging=jar
 jdk:
-  - oraclejdk7
+  - oraclejdk8


### PR DESCRIPTION
Fixes issues mentioned in #26 (hopefully). This issue is mentioned in travis-ci/travis-ci#8348. Root cause is that Oracle no longer provides Java 7 or below, so Travis (or more precisely, WebUpd8 team) removed it. Let’s move to Java 8!