### PR TITLE
Fixes Burp response markers position

### DIFF
--- a/retirejs-burp-plugin/src/main/java/burp/BurpExtender.java
+++ b/retirejs-burp-plugin/src/main/java/burp/BurpExtender.java
@@ -17,12 +17,22 @@ public class BurpExtender implements IBurpExtender, IScannerCheck {
 
     private IBurpExtenderCallbacks callbacks;
     private IExtensionHelpers helpers;
+    private static BurpExtender extender;
 
+
+    public static BurpExtender getInstance() {
+        return extender;
+    }
+
+    public IExtensionHelpers getHelpers() {
+        return this.callbacks.getHelpers();
+    }
 
     @Override
     public void registerExtenderCallbacks(final IBurpExtenderCallbacks callbacks) {
 
         this.callbacks = callbacks;
+        BurpExtender.extender = this;
         this.helpers = callbacks.getHelpers();
         this.callbacks.setExtensionName("Retire.js");
 

--- a/retirejs-burp-plugin/src/main/java/burp/vuln/MockHttpRequestResponse.java
+++ b/retirejs-burp-plugin/src/main/java/burp/vuln/MockHttpRequestResponse.java
@@ -1,5 +1,6 @@
 package burp.vuln;
 
+import burp.BurpExtender;
 import burp.IHttpRequestResponse;
 import burp.IHttpRequestResponseWithMarkers;
 import burp.IHttpService;
@@ -105,7 +106,7 @@ public class MockHttpRequestResponse implements IHttpRequestResponseWithMarkers 
     public int[] indexFromRegex(String regex, byte[] content) {
         //NOTE : Regex are not intend to work on byte array. This will work on most JavaScript files except those with Unicode
         Pattern pattern = Pattern.compile(regex);
-        Matcher m = pattern.matcher(new String(content));
+        Matcher m = pattern.matcher(BurpExtender.getInstance().getHelpers().bytesToString(content));
 
         while (m.find()) {
             return new int[] {m.start(), m.end()};


### PR DESCRIPTION
the Burp plugin fails to set the response markers properly in all situations. For instance, at https://observador.pt/  there is an include to `//observador-observadorontime.netdna-ssl.com/wp-content/themes/observador/assets/build/js/jquery/jquery-2.1.1.min.js?ver=d44ebaa9cb983f8f98adac7e9cbace5177dbcc06`. The plugin was highlighting another completely unrelated part of the response.

The fix is basically using Burp API to convert to/from bytes/strings to ensure nothing goes wrong.