### PR TITLE
ZAP: Include evidence in alerts

### DIFF
--- a/retirejs-zap-plugin/pom.xml
+++ b/retirejs-zap-plugin/pom.xml
@@ -68,7 +68,24 @@
                             </execution>
                         </executions>
                     </plugin>
-
+                    <plugin>
+                        <groupId>com.coderplus.maven.plugins</groupId>
+                        <artifactId>copy-rename-maven-plugin</artifactId>
+                        <version>1.0</version>
+                        <executions>
+                            <execution>
+                                <id>copy-file</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>copy</goal>
+                                </goals>
+                                <configuration>
+                                    <sourceFile>${project.build.directory}\retirejs-${zap.addon.status}-${zap.addon.version}.jar</sourceFile>
+                                    <destinationFile>${project.build.directory}\retirejs-${zap.addon.status}-${zap.addon.version}.zap</destinationFile>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
                 </plugins>
             </build>
 

--- a/retirejs-zap-plugin/src/main/java/org/zaproxy/zap/extension/retirejs/ZapIssueCreator.java
+++ b/retirejs-zap-plugin/src/main/java/org/zaproxy/zap/extension/retirejs/ZapIssueCreator.java
@@ -53,20 +53,24 @@ public class ZapIssueCreator {
         String evidence = "";
         String responseRegex = lib.getRegexResponse() == null ? "" : lib.getRegexResponse();
         if (!responseRegex.isEmpty()) {
-            String respBody = message.getResponseBody().toString();
-            Matcher respMatcher = Pattern.compile(responseRegex).matcher(respBody);
-            if (respMatcher.find()) {
-                evidence = respMatcher.group(0);
-            }
+            evidence = getSpecificEvidence(responseRegex, message.getResponseBody().toString());
         }
-        if (evidence.isEmpty()) { // The match wasn't from the response, try the request
+        if (evidence.isEmpty()) { // The match wasn't from the response, try the request URI
             String requestRegex = lib.getRegexRequest() == null ? "" : lib.getRegexRequest();
             if (!requestRegex.isEmpty()) {
-                String reqUri = message.getRequestHeader().getURI().toString();
-                Matcher reqMatcher = Pattern.compile(requestRegex).matcher(reqUri);
-                if (reqMatcher.find()) {
-                    evidence = reqMatcher.group(0);
-                }
+                evidence = getSpecificEvidence(requestRegex,
+                        message.getRequestHeader().getURI().toString());
+            }
+        }
+        return evidence;
+    }
+
+    private static String getSpecificEvidence(String regex, String content) {
+        String evidence = "";
+        if (!regex.isEmpty()) {
+            Matcher matcher = Pattern.compile(regex).matcher(content);
+            if (matcher.find()) {
+                evidence = matcher.group(0);
             }
         }
         return evidence;

--- a/retirejs-zap-plugin/src/main/java/org/zaproxy/zap/extension/retirejs/ZapIssueCreator.java
+++ b/retirejs-zap-plugin/src/main/java/org/zaproxy/zap/extension/retirejs/ZapIssueCreator.java
@@ -49,8 +49,7 @@ public class ZapIssueCreator {
     }
 
     private static String getEvidence(JsLibraryResult lib, HttpMessage message) {
-        String evidence = "";
-        evidence = getSpecificEvidence(lib.getRegexResponse(),
+        String evidence = getSpecificEvidence(lib.getRegexResponse(),
                 message.getResponseBody().toString());
         if (evidence.isEmpty()) { // The match wasn't from the response, try the request URI
             evidence = getSpecificEvidence(lib.getRegexRequest(),

--- a/retirejs-zap-plugin/src/main/java/org/zaproxy/zap/extension/retirejs/ZapIssueCreator.java
+++ b/retirejs-zap-plugin/src/main/java/org/zaproxy/zap/extension/retirejs/ZapIssueCreator.java
@@ -50,22 +50,18 @@ public class ZapIssueCreator {
 
     private static String getEvidence(JsLibraryResult lib, HttpMessage message) {
         String evidence = "";
-        String responseRegex = lib.getRegexResponse() == null ? "" : lib.getRegexResponse();
-        if (!responseRegex.isEmpty()) {
-            evidence = getSpecificEvidence(responseRegex, message.getResponseBody().toString());
-        }
+        evidence = getSpecificEvidence(lib.getRegexResponse(),
+                message.getResponseBody().toString());
         if (evidence.isEmpty()) { // The match wasn't from the response, try the request URI
-            String requestRegex = lib.getRegexRequest() == null ? "" : lib.getRegexRequest();
-            if (!requestRegex.isEmpty()) {
-                evidence = getSpecificEvidence(requestRegex,
-                        message.getRequestHeader().getURI().toString());
-            }
+            evidence = getSpecificEvidence(lib.getRegexRequest(),
+                    message.getRequestHeader().getURI().toString());
         }
         return evidence;
     }
 
     private static String getSpecificEvidence(String regex, String content) {
         String evidence = "";
+        regex = regex == null ? "" : regex;
         if (!regex.isEmpty()) {
             Matcher matcher = Pattern.compile(regex).matcher(content);
             if (matcher.find()) {

--- a/retirejs-zap-plugin/src/main/java/org/zaproxy/zap/extension/retirejs/ZapIssueCreator.java
+++ b/retirejs-zap-plugin/src/main/java/org/zaproxy/zap/extension/retirejs/ZapIssueCreator.java
@@ -33,7 +33,6 @@ public class ZapIssueCreator {
                 lib.getVuln().getBelow());
 
         Alert alert = new Alert(pluginId, mapToZapSeverity(lib.getVuln().getSeverity()), Alert.CONFIDENCE_MEDIUM, title);
-        String evidence = getEvidence(lib, message);
         alert.setDetail(description,
                 message.getRequestHeader().getURI().toString(),
                 "", //Param
@@ -41,7 +40,7 @@ public class ZapIssueCreator {
                 otherInfo, //Other info
                 "Update the JavaScript library", //Solution
                 joinStrings(lib.getVuln().getInfo()), //Only one line is allow
-                evidence, //Evidence
+                getEvidence(lib, message), //Evidence
                 -1, //cweId
                 -1, //wascId
                 message


### PR DESCRIPTION
- Modify `ZapIssueCreateor` to include evidence in alerts where possible/applicable. (Per:
https://github.com/zaproxy/zaproxy/issues/3742)
- Modify pom.xml to use a packaging step to copy the jar to *.zap so that it's immediately loadable by ZAP (ctrl+L > aka Load Addon).

Edit: I was originally renaming the jar, but it seems required by CI tests so now it's a copy.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>