### PR TITLE
Updating license block to Apache-2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -315,8 +315,8 @@
 
     <licenses>
         <license>
-            <name>GNU Lesser General Public License</name>
-            <url>http://www.gnu.org/copyleft/lesser.html</url>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
             <distribution>repo</distribution>
             <comments></comments>
         </license>


### PR DESCRIPTION
I notice that the code was relicensed to Apache-2.0 in 2017's https://github.com/h3xstream/burp-retire-js/issues/29 issue; but the pom.xml wasn't updated. Here's an update for the parent pom to change the license from LGPL to Apache-2.0.