### PR TITLE
Proposed fix for "Not working correctly with latest RetireJS repo" issue#73

### DIFF
--- a/retirejs-core/src/main/java/com/h3xstream/retirejs/repo/VulnerabilitiesRepository.java
+++ b/retirejs-core/src/main/java/com/h3xstream/retirejs/repo/VulnerabilitiesRepository.java
@@ -113,9 +113,7 @@ public class VulnerabilitiesRepository {
             }
             for(String contentRegex : lib.getFileContents()) {
 
-                //Extract version
-                Pattern p = Pattern.compile(contentRegex);
-                String version = RegexUtil.simpleMatch(p,scriptContent);
+                String version = extractVersion(scriptContent, contentRegex);
 
                 if(version != null) { //Pattern match
                     Log.debug("Pattern match \""+contentRegex+"\" !");
@@ -130,6 +128,18 @@ public class VulnerabilitiesRepository {
         long delta = System.currentTimeMillis()-before;
         Log.debug("It took ~"+ (int)(delta/1000.0) +" sec. (" + delta + " ms) to scan");
         return res;
+    }
+
+    private String extractVersion(String scriptContent, String contentRegex) {
+        try {
+            Pattern p = Pattern.compile(contentRegex);
+            String version = RegexUtil.simpleMatch(p,scriptContent);
+            return version;
+        }
+        catch (Exception any) {
+            Log.warn(String.format("Unable to extract version using regex '%s'", contentRegex));
+            return null;
+        }
     }
 
 

--- a/retirejs-core/src/main/java/com/h3xstream/retirejs/util/RegexUtil.java
+++ b/retirejs-core/src/main/java/com/h3xstream/retirejs/util/RegexUtil.java
@@ -71,6 +71,9 @@ public class RegexUtil {
         if(regex.contains("\n")) {
             regex = regex.replaceAll("\n","\\\\n");
         }
+        if(regex.contains("[")) {
+            regex = regex.replaceAll("\\[\\]", "\\\\[\\\\]"); // see https://github.com/RetireJS/retire.js/issues/382 for jquery.datatables
+        }
         return regex;
     }
 }

--- a/retirejs-core/src/test/java/com/h3xstream/retirejs/util/RegexUtilReplaceVersionTest.java
+++ b/retirejs-core/src/test/java/com/h3xstream/retirejs/util/RegexUtilReplaceVersionTest.java
@@ -1,0 +1,44 @@
+package com.h3xstream.retirejs.util;
+
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.Test;
+
+public class RegexUtilReplaceVersionTest {
+    
+    @Test
+    public void shouldReplaceVersionString() {
+        String source = "§§version§§";
+
+        String escaped  = RegexUtil.replaceVersion(source);
+        
+        assertEquals(escaped, "[0-9][0-9.a-z_\\\\\\\\-]+");
+    }
+    
+    @Test
+    public void shouldReplaceNewlines() {
+        String source = "/\\*!?[\n *]";
+
+        String escaped  = RegexUtil.replaceVersion(source);
+        
+        assertEquals(escaped, "/\\*!?[\\n *]");
+    }
+    
+    @Test
+    public void shouldReplaceCurlyBracesPairs() {
+        String source = "a=t.Backbone={}}";
+
+        String escaped  = RegexUtil.replaceVersion(source);
+
+        assertEquals(escaped, "a=t.Backbone=\\{\\}}");
+    }
+    
+    @Test
+    public void shouldReplaceSquareBracesPairs() {
+        String source = ";u.settings=[]";
+
+        String escaped  = RegexUtil.replaceVersion(source);
+
+        assertEquals(escaped, ";u.settings=\\[\\]");
+    }
+}

--- a/retirejs-core/src/test/resources/retirejs_repository_test.json
+++ b/retirejs-core/src/test/resources/retirejs_repository_test.json
@@ -726,6 +726,45 @@
 		}
 	},
 
+	"jquery.datatables" : {
+		"vulnerabilities" : [
+			{	
+				"below" : "1.10.10",
+				"identifiers" : {
+					"summary" : "possible XSS"
+				},
+				"info" : [ "https://github.com/DataTables/DataTables/commit/6f67df2d21f9858ec40a6e9565c3a653cdb691a6" ]
+			},
+			{	
+				"below" : "1.10.8",
+				"identifiers" : {
+					"CVE" : [ "CVE-2015-6584" ],
+					"summary" : "XSS"
+				},
+				"info" : [ "https://github.com/DataTables/DataTablesSrc/commit/ccf86dc5982bd8e16d", "https://www.invicti.com/web-applications-advisories/cve-2015-6384-xss-vulnerability-identified-in-datatables/" ]
+			}
+
+		],
+		"extractors" : {
+			"uri": [ "/(§§version§§)/(js/)?jquery.dataTables.min.js" ],
+			"filename" : [ "jquery.dataTables-(§§version§§)(\\.min)?\\.js" ],
+			"filecontent"	: [ "http://www.datatables.net\n +DataTables (§§version§§)", "u.version=\"(§§version§§)\";u.settings=[];u.models={};u.models.oSearch" ],
+			"func" : [ "DataTable && DataTable.version" ]
+		}
+	},
+	
+	"sample-with-bad-regex": {
+		"vulnerabilities" : [
+			{ "below" : "0.0.BAD", "info" : [ "https://github.com/h3xstream/burp-retire-js/issues/73" ] }
+		],
+		"extractors" : {
+			"filecontent"	: [ "?[[[  Intentionally wrong regex that should be logged andignored" ],
+			"hashes"		: {}
+		}
+	},
+
+	
+	
 	"dont check" : {
 		"extractors" : {
 			"uri" : [


### PR DESCRIPTION
Proposed fix for https://github.com/h3xstream/burp-retire-js/issues/73

This is due to the RetireJS upstream addition of a specific regex to catch jquery.datatables in its json feed, see https://github.com/RetireJS/retire.js/issues/382
I also added a log&ignore logic to avoid this to happen in the future: when a regex is not understood, is logged and ignored.

Basic fix:
- added new unit test for RegexUtil::replaceVersion
- added new entry in retirejs_repository_test.json to include the new case
- added new functionality to escape []

To avoid this in the future:
- added new ignore logic to log and discard regex that cannot be converted
- added invalid regex entry on retirejs_repository_test.json to validate the regex discard logic